### PR TITLE
Who poll improvements

### DIFF
--- a/Components.lua
+++ b/Components.lua
@@ -979,13 +979,18 @@ function MessageBox:OpenDetachedWindow(contact)
     if not contact then return end
     
     if self.detachedWindows[contact] then
-        self.detachedWindows[contact]:Show()
+        local w = self.detachedWindows[contact]
+        w:Show()
+        MessageBox:AddToWhoQueue(contact)
+        if w.UpdateHeader then w:UpdateHeader() end
         return
     end
 
     if not self.conversations[contact] then
         self.conversations[contact] = self:NewConversation()
     end
+
+    MessageBox:AddToWhoQueue(contact)
 
     local f = CreateFrame("Frame", "MessageBoxDetached_"..contact, UIParent)
     local L = MessageBox.layout
@@ -1039,6 +1044,12 @@ function MessageBox:OpenDetachedWindow(contact)
     local title = f:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
     title:SetPoint("TOP", 0, -10)
     
+    local raceClassSub = f:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    raceClassSub:SetPoint("BOTTOMLEFT", title, "BOTTOMRIGHT", 6, 2)
+    raceClassSub:SetJustifyH("LEFT")
+    raceClassSub:SetTextColor(0.67, 0.67, 0.67)
+    f.raceClassSub = raceClassSub
+
     local displayTitle = contact
     local cache = self.playerCache[contact]
     if cache and cache.class then
@@ -1048,7 +1059,37 @@ function MessageBox:OpenDetachedWindow(contact)
         end
     end
     title:SetText(displayTitle)
+    do
+        local tag = MessageBox:RaceClassTagline(cache)
+        if tag and tag ~= "" then
+            raceClassSub:SetText(tag)
+            raceClassSub:Show()
+        else
+            raceClassSub:SetText("")
+            raceClassSub:Hide()
+        end
+    end
     f.title = title
+
+    f.UpdateHeader = function()
+        local c = MessageBox.playerCache[contact]
+        local dt = contact
+        if c and c.class then
+            local color = RAID_CLASS_COLORS[c.classUpper]
+            if color then
+                dt = string.format("|cff%02x%02x%02x%s|r", color.r*255, color.g*255, color.b*255, contact)
+            end
+        end
+        f.title:SetText(dt)
+        local tag = MessageBox:RaceClassTagline(c)
+        if tag and tag ~= "" then
+            f.raceClassSub:SetText(tag)
+            f.raceClassSub:Show()
+        else
+            f.raceClassSub:SetText("")
+            f.raceClassSub:Hide()
+        end
+    end
 
     local closeBtn = CreateFrame("Button", nil, f, "UIPanelCloseButton")
     closeBtn:SetPoint("TOPRIGHT", -5, -5)

--- a/Core.lua
+++ b/Core.lua
@@ -186,8 +186,19 @@ MessageBox.defaultSettings = {
     textColor = {1, 1, 1, 1},
     selectionColor = {0.8, 0.8, 0.8, 0.4},
     gmList = {},
-    classCache = {},  -- Persistent class/level data: { ["Name"] = { class="Mage", classUpper="MAGE", level=60 }, ... }
+    classCache = {},  -- Persistent: class, classUpper, level, race (optional), ...
 }
+
+-- Subheader line from /who cache: "Orc Warrior", or class/race alone if only one is known.
+function MessageBox:RaceClassTagline(cache)
+    if not cache then return nil end
+    if cache.race and cache.race ~= "" and cache.class and cache.class ~= "" then
+        return cache.race .. " " .. cache.class
+    end
+    if cache.class and cache.class ~= "" then return cache.class end
+    if cache.race and cache.race ~= "" then return cache.race end
+    return nil
+end
 
 -- Get message count for a conversation
 function MessageBox:GetCount(c)

--- a/Logic.lua
+++ b/Logic.lua
@@ -1,5 +1,7 @@
 -- Logic.lua
 -- Who lookups, Hooks, Message storage
+-- Background WHO uses FriendsFrame_OnEvent + SetWhoToUI so the default WHO UI
+-- does not pop; the 1 Hz queue drives SendWho; WHO_LIST_UPDATE may also arrive on our event frame.
 
 -- Who lookups
 function MessageBox:AddToWhoQueue(name)
@@ -50,6 +52,7 @@ function MessageBox:ProcessWhoQueue()
             MessageBox.waitingForWhoResult = false
             MessageBox.currentWhoEntry = nil
             MessageBox.whoTimer = now
+            if SetWhoToUI then SetWhoToUI(0) end
         end
         return
     end
@@ -85,7 +88,8 @@ function MessageBox:ProcessWhoQueue()
     MessageBox.waitingForWhoResult = true
     MessageBox.waitingForWhoSince = now
     MessageBox.currentWhoEntry = entry
-    SendWho("n-" .. entry.name)
+    if SetWhoToUI then SetWhoToUI(1) end
+    SendWho('n-"' .. entry.name .. '"')
 end
 
 function MessageBox:HandleWhoResult()
@@ -119,6 +123,9 @@ function MessageBox:HandleWhoResult()
                 MessageBox.settings.classCache[name].classUpper = string.upper(class)
                 if level and tonumber(level) == 60 then
                     MessageBox.settings.classCache[name].level = level
+                end
+                if race and race ~= "" then
+                    MessageBox.settings.classCache[name].race = race
                 end
             end
             
@@ -169,6 +176,8 @@ function MessageBox:HandleWhoResult()
             MessageBox.detachedWindows[targetName]:UpdateHeader()
         end
     end
+
+    if SetWhoToUI then SetWhoToUI(0) end
 end
 
 function MessageBox:PrintWhoQueue()
@@ -198,7 +207,40 @@ function MessageBox:ClearWhoQueue()
     MessageBox.whoQueue = {}
     MessageBox.waitingForWhoResult = false
     MessageBox.currentWhoEntry = nil
+    if SetWhoToUI then SetWhoToUI(0) end
     DEFAULT_CHAT_FRAME:AddMessage("|cff3cb7f0Message|rBox: WHO Queue cleared.")
+end
+
+-- WHO_LIST_UPDATE is delivered via FriendsFrame_OnEvent; we consume it here while a background
+-- lookup is in progress so Blizzard UI does not open.
+function MessageBox:FriendsFrame_OnEvent_Hook()
+    if event == "WHO_LIST_UPDATE" then
+        if self.waitingForWhoResult then
+            self:HandleWhoResult()
+            return
+        end
+    end
+    return self.original_FriendsFrame_OnEvent(event)
+end
+
+-- FriendsFrame may not exist at first SetupHooks; call again from PLAYER_LOGIN if needed.
+function MessageBox:SetupWhoFrameHooks()
+    if FriendsFrame_OnEvent and not self.original_FriendsFrame_OnEvent then
+        self.original_FriendsFrame_OnEvent = FriendsFrame_OnEvent
+        FriendsFrame_OnEvent = function()
+            return MessageBox:FriendsFrame_OnEvent_Hook()
+        end
+    end
+
+    if WhoList_Update and not self.original_WhoList_Update then
+        self.original_WhoList_Update = WhoList_Update
+        WhoList_Update = function()
+            if MessageBox.waitingForWhoResult then
+                return
+            end
+            return MessageBox.original_WhoList_Update()
+        end
+    end
 end
 
 -- Hooks
@@ -250,6 +292,8 @@ function MessageBox:SetupHooks()
             return MessageBox.original_ChatEdit_ParseText(editBox, send)
         end
     end
+
+    self:SetupWhoFrameHooks()
 end
 
 -- Message storage

--- a/MessageBox.lua
+++ b/MessageBox.lua
@@ -8,7 +8,6 @@ function MessageBox:OnLoad()
     MessageBox.eventFrame:RegisterEvent("PLAYER_LOGIN")
     MessageBox.eventFrame:RegisterEvent("FRIENDLIST_UPDATE")
     MessageBox.eventFrame:RegisterEvent("CHAT_MSG_SYSTEM")
-    MessageBox.eventFrame:RegisterEvent("WHO_LIST_UPDATE")
     MessageBox.eventFrame:RegisterEvent("CHAT_MSG_AFK")
     MessageBox.eventFrame:RegisterEvent("CHAT_MSG_DND")
     
@@ -45,7 +44,6 @@ function MessageBox:OnLoad()
         MessageBox.whoElapsed = 0
         MessageBox:ProcessWhoQueue()
 
-        -- Periodic crash save flush
         if MessageBox.hasNampower then
             MessageBox.flushElapsed = (MessageBox.flushElapsed or 0) + 1
             if MessageBox.flushElapsed >= MessageBox.FLUSH_INTERVAL then
@@ -117,11 +115,16 @@ function MessageBox:OnEvent(event)
                 if info.level then
                     MessageBox.playerCache[name].level = info.level
                 end
+                if info.race then
+                    MessageBox.playerCache[name].race = info.race
+                end
             end
         end
 
         MessageBox.searchQuery = "" 
         MessageBox:CreateMinimapButton()
+
+        MessageBox:SetupWhoFrameHooks()
 
     elseif event == "CHAT_MSG_WHISPER" then
         local message = arg1
@@ -200,9 +203,6 @@ function MessageBox:OnEvent(event)
             MessageBox:MarkContactListDirty()
         end
         
-    elseif event == "WHO_LIST_UPDATE" then
-        MessageBox:HandleWhoResult()
-    
     elseif event == "CHAT_MSG_AFK" then
         local message = arg1
         local sender = arg2

--- a/UI.lua
+++ b/UI.lua
@@ -167,8 +167,14 @@ function MessageBox:CreateChatHeader(parent)
     nameText:SetJustifyH("LEFT")
     header.nameText = nameText
 
+    local raceClassText = header:CreateFontString(nil, "OVERLAY", "GameFontNormalSmall")
+    raceClassText:SetPoint("BOTTOMLEFT", nameText, "BOTTOMRIGHT", 4, 1)
+    raceClassText:SetJustifyH("LEFT")
+    raceClassText:SetTextColor(0.67, 0.67, 0.67)
+    header.raceClassText = raceClassText
+
     local guildText = header:CreateFontString(nil, "OVERLAY", "GameFontHighlightSmall")
-    guildText:SetPoint("LEFT", nameText, "RIGHT", 6, 0)
+    guildText:SetPoint("BOTTOMLEFT", nameText, "BOTTOMRIGHT", 6, 0)
     guildText:SetJustifyH("LEFT")
     guildText:SetTextColor(0.5, 0.5, 0.5)
     header.guildText = guildText
@@ -278,6 +284,10 @@ function MessageBox:UpdateChatHeader()
         self.chatHeader.searchBtn:Hide()
         self.chatHeader.guildText:Hide()
         self.chatHeader.metaTopText:Hide()
+        if self.chatHeader.raceClassText then
+            self.chatHeader.raceClassText:SetText("")
+            self.chatHeader.raceClassText:Hide()
+        end
         return
     end
 
@@ -322,6 +332,12 @@ function MessageBox:UpdateChatHeader()
         -- GM: special display — skip level/guild, show GM badge
         displayTitle = "|cff00ccffGM " .. name .. "|r"
         self.chatHeader.nameText:SetText(displayTitle)
+        if self.chatHeader.raceClassText then
+            self.chatHeader.raceClassText:SetText("")
+            self.chatHeader.raceClassText:Hide()
+        end
+        self.chatHeader.guildText:ClearAllPoints()
+        self.chatHeader.guildText:SetPoint("BOTTOMLEFT", self.chatHeader.nameText, "BOTTOMRIGHT", 6, 0)
         
         self.chatHeader.guildText:SetText("|cff00ccff<Game Master>|r")
         self.chatHeader.guildText:Show()
@@ -337,8 +353,22 @@ function MessageBox:UpdateChatHeader()
                 displayTitle = string.format("|cff%02x%02x%02x%s|r", color.r*255, color.g*255, color.b*255, name)
             end
         end
-        
         self.chatHeader.nameText:SetText(displayTitle)
+
+        local rcTag = MessageBox:RaceClassTagline(cache)
+        if self.chatHeader.raceClassText then
+            if rcTag and rcTag ~= "" then
+                self.chatHeader.raceClassText:SetText(rcTag)
+                self.chatHeader.raceClassText:Show()
+                self.chatHeader.guildText:ClearAllPoints()
+                self.chatHeader.guildText:SetPoint("BOTTOMLEFT", self.chatHeader.raceClassText, "BOTTOMRIGHT", 6, 0)
+            else
+                self.chatHeader.raceClassText:SetText("")
+                self.chatHeader.raceClassText:Hide()
+                self.chatHeader.guildText:ClearAllPoints()
+                self.chatHeader.guildText:SetPoint("BOTTOMLEFT", self.chatHeader.nameText, "BOTTOMRIGHT", 6, 0)
+            end
+        end
 
         -- AFK/DND status display
         if cache and cache.status and cache.status ~= "" then
@@ -1251,6 +1281,9 @@ function MessageBox:SelectContact(contact)
     if MessageBox.whisperInput then
         MessageBox.whisperInput:SetFocus()
     end
+
+    -- Background /who for class/guild when focusing this contact (e.g. chat name click → whisper).
+    MessageBox:AddToWhoQueue(contact)
 end
 
 function MessageBox:UpdateChatHistory(unreadCount, resetToBottom)


### PR DESCRIPTION
We hook FriendsFrame_OnEvent so that when WHO_LIST_UPDATE fires for a background /who, we can handle it and return without calling Blizzard’s handler. That stops the default WHO / Friends UI from opening or refreshing for that update.

Listening on our own frame still lets us react to the same event, but it does not turn off that default UI path. The hook does.

Chat / /who results: the server still fills the same WHO result buffer; we read it with GetNumWhoResults() / GetWhoInfo() as usual. What changes is only presentation: the stock WHO window stays quiet while we use those rows for class/race/guild in MessageBox.